### PR TITLE
Rewrite storage provisioning.

### DIFF
--- a/helm/slurm-cluster/templates/deployment.yaml
+++ b/helm/slurm-cluster/templates/deployment.yaml
@@ -48,12 +48,18 @@ spec:
           volumeMounts:
             - name: etc-slurm-dir
               mountPath: /etc/slurm
-            - name: etc-munge-dir
-              mountPath: /etc/munge
             - name: run-dbus-dir
               mountPath: /run/dbus
             - name: var-spool-slurmd-dir
               mountPath: /var/spool/slurmd
+            {{- range $component, $config := (dict "munge" .Values.volumes.munge "slurmd" .Values.volumes.slurmd) }}
+            {{- if $config }}
+            {{- range $config }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: 6818
@@ -68,13 +74,19 @@ spec:
             name: {{ include "slurm-cluster.fullname" . }}-slurm-config
         - name: etc-slurm-dir
           emptyDir: {}
-        - name: etc-munge-dir
-          persistentVolumeClaim:
-            claimName: {{ include "slurm-cluster.fullname" . }}-munge-pvc
         - name: run-dbus-dir
           emptyDir: {}
         - name: var-spool-slurmd-dir
           emptyDir: {}
+        {{- range $component, $config := (dict "munge" .Values.volumes.munge "slurmd" .Values.volumes.slurmd) }}
+        {{- if $config }}
+        {{- range $config }}
+        - name: {{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pvc
+        {{- end }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/slurm-cluster/templates/persistentvolume.yaml
+++ b/helm/slurm-cluster/templates/persistentvolume.yaml
@@ -1,83 +1,23 @@
+{{- range $component, $config := (dict "mariadb" .Values.volumes.mariadb "munge" .Values.volumes.munge "slurmdbd" .Values.volumes.slurmdbd "slurmctld" .Values.volumes.slurmctld "slurmd" .Values.volumes.slurmd) }}
+{{- if $config }}
+{{- range $config }}
+{{- if not .volumeName }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "slurm-cluster.fullname" . }}-mariadb-pv
+  name: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
   labels:
-    {{- include "slurm-cluster.labels" . | nindent 4 }}
-    app.kubernetes.io/component: mariadb
+    {{- include "slurm-cluster.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $component }}
 spec:
   capacity:
-    storage: {{ .Values.mariadb.storage.data.size }}
-  volumeMode: Filesystem
-  accessModes:
-  - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ .Values.mariadb.storage.data.storageClass }}
-  local:
-    path: {{ .Values.mariadb.storage.data.localPath }}
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values:
-          {{- range .Values.mariadb.storage.data.nodeAffinityHostnames }}
-          - {{ . }}
-          {{- end }}
+    storage: {{ .size }}
+  accessModes: {{ .accessModes | toJson }}
+  persistentVolumeReclaimPolicy: {{ .reclaimPolicy | default "Retain" }}
+  storageClassName: {{ .storageClassName }}
+  {{- toYaml .spec | nindent 2 }}
 ---
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: {{ include "slurm-cluster.fullname" . }}-munge-pv
-  labels:
-    {{- include "slurm-cluster.labels" . | nindent 4 }}
-    app.kubernetes.io/component: munge
-spec:
-  capacity:
-    storage: {{ .Values.munge.storage.data.size }}
-  volumeMode: Filesystem
-  accessModes:
-  - ReadWriteMany
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ .Values.munge.storage.data.storageClass }}
-  local:
-    path: {{ .Values.munge.storage.data.localPath }}
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values:
-          {{- range .Values.munge.storage.data.nodeAffinityHostnames }}
-          - {{ . }}
-          {{- end }}
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: {{ include "slurm-cluster.fullname" . }}-slurmctld-spool-pv
-  labels:
-    {{- include "slurm-cluster.labels" . | nindent 4 }}
-    app.kubernetes.io/component: slurmctld
-spec:
-  capacity:
-    storage: {{ .Values.slurmctld.storage.data.size }}
-  volumeMode: Filesystem
-  accessModes:
-  - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ .Values.slurmctld.storage.data.storageClass }}
-  local:
-    path: {{ .Values.slurmctld.storage.data.localPath }}
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values:
-          {{- range .Values.slurmctld.storage.data.nodeAffinityHostnames }}
-          - {{ . }}
-          {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/slurm-cluster/templates/persistentvolumeclaim.yaml
+++ b/helm/slurm-cluster/templates/persistentvolumeclaim.yaml
@@ -1,15 +1,28 @@
+{{- range $component, $config := (dict "munge" .Values.volumes.munge "slurmd" .Values.volumes.slurmd) }}
+{{- if $config }}
+{{- range $config }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "slurm-cluster.fullname" . }}-munge-pvc
+  name: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pvc
   labels:
-    {{- include "slurm-cluster.labels" . | nindent 4 }}
-    app.kubernetes.io/component: munge
+    {{- include "slurm-cluster.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $component }}
 spec:
-  storageClassName: {{ .Values.munge.storage.data.storageClass }}
-  volumeName: {{ include "slurm-cluster.fullname" . }}-munge-pv
-  accessModes:
-    - ReadWriteMany
+  accessModes: {{ .accessModes | toJson }}
   resources:
     requests:
-      storage: {{ .Values.munge.storage.data.size }}
+      storage: {{ .size }}
+  {{- if and .volumeName (not .storageClass) }}
+  volumeName: {{ .volumeName }}
+  {{- else if and .storageClass (not .volumeName) }}
+  volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+  storageClassName: {{ .storageClass }}
+  {{- else }}
+  volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+  storageClassName: {{ .storageClassName }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/slurm-cluster/templates/statefulset.yaml
+++ b/helm/slurm-cluster/templates/statefulset.yaml
@@ -314,7 +314,7 @@ spec:
           image: {{ .Values.slurmd.deployment.image }}
           imagePullPolicy: Always
           resources:
-            {{- toYaml .Values.nodeController.deployment.resources | nindent 12 }}
+            {{- toYaml .Values.nodeWatcher.deployment.resources | nindent 12 }}
           command: ["/bin/bash"]
           args:
             - /usr/local/bin/entrypoint.sh

--- a/helm/slurm-cluster/templates/statefulset.yaml
+++ b/helm/slurm-cluster/templates/statefulset.yaml
@@ -42,8 +42,12 @@ spec:
           ports:
             - containerPort: 3306
           volumeMounts:
-            - name: mariadb-data
-              mountPath: /var/lib/mysql
+            {{- if .Values.volumes.mariadb }}
+            {{- range .Values.volumes.mariadb }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
             - name: mariadb-config
               mountPath: /etc/mysql/conf.d
           livenessProbe:
@@ -71,15 +75,28 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
+    {{- if .Values.volumes.mariadb }}
+    {{- range .Values.volumes.mariadb }}
     - metadata:
-        name: mariadb-data
+        name: {{ .name }}
+        labels:
+          app.kubernetes.io/component: mariadb
       spec:
-        accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.mariadb.storage.data.storageClass | quote }}
+        accessModes: {{ .accessModes | toJson }}
+        {{- if and .volumeName (not .storageClass) }}
+        volumeName: {{ .volumeName }}
+        {{- else if and .storageClass (not .volumeName) }}
+        volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+        storageClassName: {{ .storageClass }}
+        {{- else }}
+        volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+        storageClassName: {{ .storageClassName }}
+        {{- end }}
         resources:
           requests:
-            storage: {{ .Values.mariadb.storage.data.size | quote }}
-        volumeMode: Filesystem
+            storage: {{ .size }}
+    {{- end }}
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -105,10 +122,10 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: copy-slurmdbd-conf
-          image: {{ .Values.slurmdbdd.deployment.image }}
+          image: {{ .Values.slurmdbd.deployment.image }}
           imagePullPolicy: Always
           resources:
-            {{- toYaml .Values.slurmdbdd.deployment.resources | nindent 12 }}
+            {{- toYaml .Values.slurmdbd.deployment.resources | nindent 12 }}
           command: ["/bin/bash"]
           args:
             - -c
@@ -135,10 +152,10 @@ spec:
                   key: password
       containers:
         - name: slurmdbd
-          image: {{ .Values.slurmdbdd.deployment.image }}
+          image: {{ .Values.slurmdbd.deployment.image }}
           imagePullPolicy: Always
           resources:
-            {{- toYaml .Values.slurmdbdd.deployment.resources | nindent 12 }}
+            {{- toYaml .Values.slurmdbd.deployment.resources | nindent 12 }}
           command: ["/bin/bash"]
           args:
             - /usr/local/bin/entrypoint.sh 
@@ -146,8 +163,14 @@ spec:
           volumeMounts:
             - name: etc-slurm-dir
               mountPath: /etc/slurm
-            - name: etc-munge-dir
-              mountPath: /etc/munge
+            {{- range $component, $config := (dict "munge" .Values.volumes.munge "slurmdbd" .Values.volumes.slurmdbd) }}
+            {{- if $config }}
+            {{- range $config }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - containerPort: 6819
           livenessProbe:
@@ -164,9 +187,34 @@ spec:
             name: {{ include "slurm-cluster.fullname" . }}-slurmdbd-config
         - name: etc-slurm-dir
           emptyDir: {}
-        - name: etc-munge-dir
+        {{- range .Values.volumes.munge }}
+        - name: {{ .name }}
           persistentVolumeClaim:
-            claimName: {{ include "slurm-cluster.fullname" . }}-munge-pvc
+            claimName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pvc
+        {{- end }}
+  volumeClaimTemplates:
+    {{- if .Values.volumes.slurmdbd }}
+    {{- range .Values.volumes.slurmdbd }}
+    - metadata:
+        name: {{ .name }}
+        labels:
+          app.kubernetes.io/component: slurmdbd
+      spec:
+        accessModes: {{ .accessModes | toJson }}
+        {{- if and .volumeName (not .storageClass) }}
+        volumeName: {{ .volumeName }}
+        {{- else if and .storageClass (not .volumeName) }}
+        volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+        storageClassName: {{ .storageClass }}
+        {{- else }}
+        volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+        storageClassName: {{ .storageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .size }}
+    {{- end }}
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -192,10 +240,10 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: copy-slurmdbd-conf
-          image: {{ .Values.slurmdbdd.deployment.image }}
+          image: {{ .Values.slurmdbd.deployment.image }}
           imagePullPolicy: Always
           resources:
-            {{- toYaml .Values.slurmdbdd.deployment.resources | nindent 12 }}
+            {{- toYaml .Values.slurmdbd.deployment.resources | nindent 12 }}
           command: ["/bin/bash"]
           args:
             - -c
@@ -248,10 +296,14 @@ spec:
           volumeMounts:
             - name: etc-slurm-dir
               mountPath: /etc/slurm
-            - name: etc-munge-dir
-              mountPath: /etc/munge
-            - name: slurmctld-spool
-              mountPath: /var/spool/slurmctld
+            {{- range $component, $config := (dict "munge" .Values.volumes.munge "slurmctld" .Values.volumes.slurmctld) }}
+            {{- if $config }}
+            {{- range $config }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: 6817
@@ -269,22 +321,34 @@ spec:
             name: {{ include "slurm-cluster.fullname" . }}-slurm-config
         - name: etc-slurm-dir
           emptyDir: {}
-        - name: etc-munge-dir
+        {{- range .Values.volumes.munge }}
+        - name: {{ .name }}
           persistentVolumeClaim:
-            claimName: {{ include "slurm-cluster.fullname" . }}-munge-pvc
+            claimName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pvc
+        {{- end }}
   volumeClaimTemplates:
+    {{- if .Values.volumes.slurmctld }}
+    {{- range .Values.volumes.slurmctld }}
     - metadata:
-        name: slurmctld-spool
+        name: {{ .name }}
         labels:
-          {{- include "slurm-cluster.labels" . | nindent 10 }}
           app.kubernetes.io/component: slurmctld
       spec:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: {{ .Values.slurmctld.storage.data.storageClass }}
+        accessModes: {{ .accessModes | toJson }}
+        {{- if and .volumeName (not .storageClass) }}
+        volumeName: {{ .volumeName }}
+        {{- else if and .storageClass (not .volumeName) }}
+        volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+        storageClassName: {{ .storageClass }}
+        {{- else }}
+        volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+        storageClassName: {{ .storageClassName }}
+        {{- end }}
         resources:
           requests:
-            storage: {{ .Values.slurmctld.storage.data.size }}
+            storage: {{ .size }}
+    {{- end }}
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -325,10 +389,16 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           volumeMounts:
+            {{- range $component, $config := (dict "munge" .Values.volumes.munge "nodeWatcher" .Values.volumes.nodeWatcher) }}
+            {{- if $config }}
+            {{- range $config }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             - name: etc-slurm-dir
               mountPath: /etc/slurm
-            - name: etc-munge-dir
-              mountPath: /etc/munge
           livenessProbe:
             exec:
               command: ["pgrep", "-f", "slurm-node-watcher.py"]
@@ -341,6 +411,31 @@ spec:
         - name: etc-slurm-dir
           configMap:
             name: {{ include "slurm-cluster.fullname" . }}-slurm-config
-        - name: etc-munge-dir
+        {{- range .Values.volumes.munge }}
+        - name: {{ .name }}
           persistentVolumeClaim:
-            claimName: {{ include "slurm-cluster.fullname" . }}-munge-pvc
+            claimName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pvc
+        {{- end }}
+  volumeClaimTemplates:
+    {{- if .Values.volumes.nodeWatcher }}
+    {{- range .Values.volumes.nodeWatcher }}
+    - metadata:
+        name: {{ .name }}
+        labels:
+          app.kubernetes.io/component: node-watcher
+      spec:
+        accessModes: {{ .accessModes | toJson }}
+        {{- if and .volumeName (not .storageClass) }}
+        volumeName: {{ .volumeName }}
+        {{- else if and .storageClass (not .volumeName) }}
+        volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+        storageClassName: {{ .storageClass }}
+        {{- else }}
+        volumeName: {{ include "slurm-cluster.fullname" $ }}-{{ .name }}-pv
+        storageClassName: {{ .storageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .size }}
+    {{- end }}
+    {{- end }}

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -74,8 +74,8 @@ slurmd:
         memory: "4Gi"
         cpu: "1000m"
 
-# The Slurm node controller (adds and removes slurmd nodes via scrontrol)
-nodeController:
+# The Slurm node watcher (adds and removes slurmd nodes via scrontrol)
+nodeWatcher:
   deployment:
     resources:
       requests:

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -13,28 +13,9 @@ mariadb:
   secret:
     username: "slurm"
     password: "${SLURM_DB_PASSWORD}"
-  storage:
-    # Storage for MariaDB data files (mounts to /var/lib/mysql)
-    data:
-      storageClass: local-ssd
-      size: 100Gi
-      localPath: /apps/slurm-cluster/mariadb/data
-      nodeAffinityHostnames:
-        - lavender
-
-# Munge configuration
-munge:
-  storage:
-    # Storage for munge key (mounts to /etc/munge)
-    data:
-      storageClass: local-ssd
-      size: 1Gi
-      localPath: /apps/slurm-cluster/munge/etc
-      nodeAffinityHostnames:
-        - lavender
 
 # Slurm components
-slurmdbdd:
+slurmdbd:
   deployment:
     image: docker-registry.jealwh.local:5000/slurm:24-11-0-1
     resources:
@@ -54,14 +35,6 @@ slurmctld:
       limits:
         memory: "4Gi"
         cpu: "2000m"
-  storage:
-    # Storage for Slurm state files (mounts to /var/spool/slurmctld)
-    data:
-      storageClass: local-ssd
-      size: 1Gi
-      localPath: /apps/slurm-cluster/slurmctld/spool
-      nodeAffinityHostnames:
-        - lavender
 slurmd:
   deployment:
     image: docker-registry.jealwh.local:5000/slurm:24-11-0-1
@@ -84,6 +57,133 @@ nodeWatcher:
       limits:
         cpu: 200m
         memory: 256Mi
+
+volumes:
+  mariadb:
+    # A persistent volume for /var/lib/mysql is required.
+    - name: mariadb-data
+      mountPath: /var/lib/mysql
+      # Optional, defaults to Retain
+      reclaimPolicy: Delete
+      size: 50Gi
+      storageClassName: local-ssd
+      accessModes:
+        - ReadWriteOnce
+      spec:
+        hostPath:
+          path: /apps/slurm-cluster/mariadb/data
+          type: DirectoryOrCreate
+        nodeAffinity:
+          required:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - lavender
+    # List more volumes and they will be mounted into the component's container.
+  munge:
+    # A persistent volume for /etc/munge is required.
+    - name: munge-etc
+      mountPath: /etc/munge
+      # Optional, defaults to Retain
+      reclaimPolicy: Delete
+      size: 1Gi
+      storageClassName: local-ssd
+      accessModes:
+        - ReadWriteMany
+      spec:
+        hostPath:
+          path: /apps/slurm-cluster/munge/etc
+          type: DirectoryOrCreate
+        nodeAffinity:
+          required:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - lavender
+    # List more volumes and they will be mounted into the component's container.
+  nodeWatcher: []
+  slurmctld:
+    # A persistent volume for /var/spool/slurmctld is required.
+    - name: slurmctld-spool
+      mountPath: /var/spool/slurmctld
+      # Optional, defaults to Retain
+      reclaimPolicy: Delete
+      size: 10Gi
+      storageClassName: local-ssd
+      accessModes:
+        - ReadWriteOnce
+      spec:
+        hostPath:
+          path: /apps/slurm-cluster/slurmctld/spool
+          type: DirectoryOrCreate
+        nodeAffinity:
+          required:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - lavender
+    # List more volumes and they will be mounted into the component's container.
+  slurmdbd: []
+  slurmd:
+    # slurmd does not require any volumes. The entries below are just examples.
+    # NFS example
+    #- name: home
+    #  mountPath: /home
+    #  # Optional, defaults to Retain
+    #  reclaimPolicy: Delete
+    #  size: 10Gi
+    #  storageClassName: local-ssd
+    #  accessModes: 
+    #    - ReadWriteMany
+    #  spec:
+    #    nfs:
+    #      server: aster.your.domain
+    #      path: /apps/slurm-cluster/slurmd/home
+
+    # HostPath example
+    #- name: data
+    #  mountPath: /data
+    #  # Optional, defaults to Retain
+    #  reclaimPolicy: Delete
+    #  size: 10Gi
+    #  storageClassName: local-ssd
+    #  accessModes:
+    #    - ReadWriteMany
+    #  spec:
+    #    hostPath:
+    #      path: /apps/slurm-cluster/slurmd/data
+    #      type: DirectoryOrCreate
+    #    nodeAffinity:
+    #      required:
+    #        nodeSelectorTerms:
+    #        - matchExpressions:
+    #          - key: kubernetes.io/hostname
+    #            operator: In
+    #            values:
+    #            - lavender
+
+    # Using an existing PV
+    #- name: shared
+    #  mountPath: /shared
+    #  size: 100Gi
+    #  volumeName: shared-pv
+    #  accessModes:
+    #    - ReadWriteMany
+
+    # Creating a new PV
+    #- name: scratch
+    #  mountPath: /scratch
+    #  size: 50Gi
+    #  type: dynamic
+    #  storageClassName: fast-storage
+    #  accessModes:
+    #    - ReadWriteOnce
 
 # Health checks
 probes:


### PR DESCRIPTION
- Now supports all volume types.
- Define the volume spec in values.yaml and it will be passed to the template.
- A new PV will only be created if volumeName is NOT defined. Otherwise, an existing PV will be used.