### PR TITLE
Update Actions workflows to only run on PRs.

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,11 +1,6 @@
 name: Ansible Lint
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - 'ansible/**'
-      - '.github/workflows/ansible-lint.yaml'
   pull_request:
     branches: [ "main" ]
     paths:

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -1,13 +1,6 @@
 name: Markdown Lint
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - '**/*.md'
-      - '.github/workflows/markdown-lint.yaml'
-      - '.mdlrc'
-      - '.mdl_styl.rb'
   pull_request:
     branches: [ "main" ]
     paths:

--- a/.github/workflows/packer-validate.yaml
+++ b/.github/workflows/packer-validate.yaml
@@ -1,11 +1,6 @@
 name: Packer Validate
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - 'packer/**'
-      - '.github/workflows/packer-validate.yaml'
   pull_request:
     branches: [ "main" ]
     paths:

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,12 +1,6 @@
 name: PyLint
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - '**/*.py'
-      - '.github/workflows/pylint.yaml'
-      - '.pylintrc'
   pull_request:
     branches: [ "main" ]
     paths:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,12 +1,6 @@
 name: ShellCheck
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - '**/*.sh'
-      - '.github/workflows/shellcheck.yaml'
-      - '.shellcheckrc'
   pull_request:
     branches: [ "main" ]
     paths:


### PR DESCRIPTION
This change will stop a duplicate run of the actions on merge. Default (main) branch is protected with a ruleset that blocks push/requires a PR.